### PR TITLE
MMA-3458 Camera attachments

### DIFF
--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -150,7 +150,7 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
                                     maxHeight:[self.options[@"maxHeight"] floatValue]];
     }
 
-    if ([self.options[@"returnOriginal"] boolValue]) {
+    if ((target != camera) && [self.options[@"returnOriginal"] boolValue]) {
         data = data;
     }
     else if ([fileType isEqualToString:@"jpg"]) {


### PR DESCRIPTION
Only return original image when one exists (never when taking a new photo).